### PR TITLE
Remove @material-ui/styles dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@material-ui/core": "^4.7.1",
     "@material-ui/icons": "^4.5.1",
-    "@material-ui/styles": "^4.7.1",
     "big.js": "^5.2.2",
     "classnames": "^2.2.6",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
Remove `@material-ui/styles` dependency because the Material-UI re-exported as `@material-ui/core/styles`.